### PR TITLE
Fix : Crash on npm start due to OpenSSL error

### DIFF
--- a/razorpay-frontend/package.json
+++ b/razorpay-frontend/package.json
@@ -12,9 +12,9 @@
   },
   "scripts": {
     "start": "react-scripts start",
-    "build": "react-scripts build",
-    "test": "react-scripts test",
-    "eject": "react-scripts eject"
+    "build": "export SET NODE_OPTIONS=--openssl-legacy-provider && react-scripts build",
+    "test": "export SET NODE_OPTIONS=--openssl-legacy-provider && react-scripts test",
+    "eject": "export SET NODE_OPTIONS=--openssl-legacy-provider && react-scripts eject"
   },
   "eslintConfig": {
     "extends": "react-app"

--- a/razorpay-frontend/package.json
+++ b/razorpay-frontend/package.json
@@ -11,7 +11,7 @@
     "react-scripts": "3.4.1"
   },
   "scripts": {
-    "start": "react-scripts start",
+    "start": "export SET NODE_OPTIONS=--openssl-legacy-provider && react-scripts start",
     "build": "export SET NODE_OPTIONS=--openssl-legacy-provider && react-scripts build",
     "test": "export SET NODE_OPTIONS=--openssl-legacy-provider && react-scripts test",
     "eject": "export SET NODE_OPTIONS=--openssl-legacy-provider && react-scripts eject"


### PR DESCRIPTION
Fixes crash on npm start due to OpenSSL error by using legacy OpenSSL provider.